### PR TITLE
Relieve main.py of having to check trigger reason

### DIFF
--- a/code-check.yml
+++ b/code-check.yml
@@ -1,0 +1,33 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Code check
+
+on:
+  push:
+    branches: [ master ]
+  pull_request_traget:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox
+    - name: Run tox
+      run: |
+       tox -e code-check

--- a/main.py
+++ b/main.py
@@ -3,12 +3,18 @@ import os
 
 import github
 
+ACTIONS = {
+    'labels_by_user_input':labels_by_user_input,
+    'add_reviewers':add_reviewers,
+    'size_label_prs': size_label_prs
+}
 
 def get_labels(pull):
     return [label.name for label in pull.get_labels()]
 
 
-def labels_by_user_input(data, pull):
+def labels_by_user_input(**kwargs):
+    data, pull = kwargs['data'], kwargs['pull']
     body = data["comment"]["body"]
     label = "Verified"
     if "/verified" in body and label not in get_labels(pull=pull):
@@ -27,7 +33,8 @@ def remove_verified_label(pull):
         pull.remove_from_labels(label)
 
 
-def add_reviewers(data, pull, reviewers):
+def add_reviewers(**kwargs):
+    data, pull, reviewers = kwargs['data'], kwargs['pull'], kwargs['reviewers']
     reviewers = [reviewer.strip() for reviewer in reviewers.split(",")]
     author = [data["sender"]["login"]]
     current_reviewers_requests = data["pull_request"]["requested_reviewers"]
@@ -37,7 +44,8 @@ def add_reviewers(data, pull, reviewers):
             pull.create_review_request([reviewer])
 
 
-def size_label_prs(data, pull):
+def size_label_prs(**kwargs):
+    data, pull = kwargs['data'], kwargs['pull']
     labels = get_labels(pull=pull)
     additions = data["pull_request"]["additions"]
     label = None
@@ -67,8 +75,8 @@ def size_label_prs(data, pull):
 
 if __name__ == "__main__":
     token = os.environ["INPUT_TOKEN"]
-    event_type = os.environ["GITHUB_EVENT_NAME"]
-    reviewers = os.environ["INPUT_REVIEWERS"]
+    reviewers = os.environ['INPUT_REVIEWERS']
+    action = os.environ['INPUT_ACTION']
     with open(os.environ.get("GITHUB_EVENT_PATH"), "r") as fd:
         data = json.load(fd)
 
@@ -82,10 +90,4 @@ if __name__ == "__main__":
 
     pull = repo.get_pull(issue_number)
 
-    if event_type == "pull_request_target":
-        remove_verified_label(pull=pull)
-        size_label_prs(data=data, pull=pull)
-        add_reviewers(data=data, pull=pull, reviewers=reviewers)
-
-    if event_type == "issue_comment":
-        labels_by_user_input(data=data, pull=pull)
+    ACTIONS[action](data=data, pull=pull, reviewers=reviewers)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = code-check,tests
+skipsdist = True
+
+[flake8]
+[testenv:code-check]
+basepython = python3
+setenv = PYTHONPATH = {toxinidir}
+deps =
+    pre-commit
+commands =
+    pre-commit run --all-files


### PR DESCRIPTION
No longer checking trigger reason in main.py
Defined workflows in ocp-python-wrapper will select desired action based on their triggers